### PR TITLE
Fix Zenodo resource type for linked publications

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -46,12 +46,12 @@
         {
             "identifier": "https://ntia.github.io/P2108/",
             "relation": "isDocumentedBy",
-            "resource_type": "softwaredocumentation"
+            "resource_type": "publication-softwaredocumentation"
         },
         {
             "identifier": "https://ntia.github.io/propagation-library-wiki/models/P2108/",
             "relation": "isDocumentedBy",
-            "resource_type": "softwaredocumentation"
+            "resource_type": "publication-softwaredocumentation"
         }
     ],
     "version": "1.0"


### PR DESCRIPTION
Fixes a Zenodo DOI generation error. After merging, a v1.0-rc.2 release candidate will be tested.